### PR TITLE
Fix carousel arrow positioning

### DIFF
--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -63,8 +63,8 @@ const Index = () => {
                       </TabsList>
                     </CarouselItem>
                   </CarouselContent>
-                  <CarouselPrevious className="left-0 h-8 w-8" />
-                  <CarouselNext className="right-0 h-8 w-8" />
+                  <CarouselPrevious />
+                  <CarouselNext />
                 </Carousel>
               </div>
 


### PR DESCRIPTION
## Summary
- avoid tab bar arrow overlays by using default Carousel arrow styling

## Testing
- `npx eslint src/pages/Index.tsx`
- `npm run lint` *(fails: Unexpected any in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68474a46200083209e905d5d12ae28c8