### PR TITLE
Improve Calendly API error handling

### DIFF
--- a/src/hooks/integrations/useCalendlyAPI.tsx
+++ b/src/hooks/integrations/useCalendlyAPI.tsx
@@ -36,6 +36,12 @@ export const useCalendlyAPI = () => {
         }
       });
 
+      if (!eventTypesResponse.ok) {
+        const errorText = await eventTypesResponse.text();
+        console.error('Calendly event types error:', eventTypesResponse.status, errorText);
+        throw new Error(`HTTP ${eventTypesResponse.status}: ${errorText || 'Failed to fetch event types'}`);
+      }
+
       const eventTypesData = await eventTypesResponse.json();
       const eventTypes = eventTypesData.collection || [];
 


### PR DESCRIPTION
## Summary
- improve error checking in Calendly API hook to surface failures fetching event types

## Testing
- `npm run build`
- `npm run lint` *(fails: Unexpected any in several files)*

------
https://chatgpt.com/codex/tasks/task_e_68473a7314d483208c852ac1228c4674