### PR TITLE
Add Google Docs/Sheets URL integrations

### DIFF
--- a/src/components/integrations/RealAPIModal.tsx
+++ b/src/components/integrations/RealAPIModal.tsx
@@ -7,6 +7,8 @@ import { AIConnectionForm } from "./forms/AIConnectionForm";
 import { TrelloConnectionForm } from "./forms/TrelloConnectionForm";
 import { GoogleCalendarConnectionForm } from "./forms/GoogleCalendarConnectionForm";
 import { CalendlyConnectionForm } from "./forms/CalendlyConnectionForm";
+import { GoogleSheetConnectionForm } from "./forms/GoogleSheetConnectionForm";
+import { GoogleDocConnectionForm } from "./forms/GoogleDocConnectionForm";
 
 interface RealAPIModalProps {
   open: boolean;
@@ -14,7 +16,15 @@ interface RealAPIModalProps {
 }
 
 export const RealAPIModal = ({ open, onOpenChange }: RealAPIModalProps) => {
-  const { connectTrelloAPI, connectGoogleCalendar, connectCalendlyAPI, connectAIAPI, isLoading } = useAPIIntegrations();
+  const {
+    connectTrelloAPI,
+    connectGoogleCalendar,
+    connectCalendlyAPI,
+    connectGoogleSheetAPI,
+    connectGoogleDocAPI,
+    connectAIAPI,
+    isLoading
+  } = useAPIIntegrations();
 
   const handleTrelloConnect = async (apiKey: string, token: string) => {
     await connectTrelloAPI(apiKey, token);
@@ -33,6 +43,16 @@ export const RealAPIModal = ({ open, onOpenChange }: RealAPIModalProps) => {
 
   const handleAIConnect = async (apiKey: string, provider: 'openai' | 'claude', model: string) => {
     await connectAIAPI(apiKey, provider, model);
+    onOpenChange(false);
+  };
+
+  const handleSheetConnect = async (url: string) => {
+    await connectGoogleSheetAPI(url);
+    onOpenChange(false);
+  };
+
+  const handleDocConnect = async (url: string) => {
+    await connectGoogleDocAPI(url);
     onOpenChange(false);
   };
 
@@ -76,6 +96,8 @@ export const RealAPIModal = ({ open, onOpenChange }: RealAPIModalProps) => {
 
           <TabsContent value="google" className="space-y-4">
             <GoogleCalendarConnectionForm onConnect={handleGoogleConnect} isLoading={isLoading} />
+            <GoogleSheetConnectionForm onConnect={handleSheetConnect} isLoading={isLoading} />
+            <GoogleDocConnectionForm onConnect={handleDocConnect} isLoading={isLoading} />
           </TabsContent>
 
           <TabsContent value="calendly" className="space-y-4">

--- a/src/components/integrations/forms/GoogleDocConnectionForm.tsx
+++ b/src/components/integrations/forms/GoogleDocConnectionForm.tsx
@@ -1,0 +1,58 @@
+import { useState } from 'react';
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import { Alert, AlertDescription } from '@/components/ui/alert';
+import { FileText } from 'lucide-react';
+
+interface GoogleDocConnectionFormProps {
+  onConnect: (url: string) => Promise<void>;
+  isLoading: boolean;
+}
+
+export const GoogleDocConnectionForm = ({ onConnect, isLoading }: GoogleDocConnectionFormProps) => {
+  const [docUrl, setDocUrl] = useState('');
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    if (!docUrl.trim()) return;
+    await onConnect(docUrl.trim());
+    setDocUrl('');
+  };
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle className="flex items-center gap-2">
+          <FileText className="w-5 h-5 text-green-500" />
+          Add Google Document
+        </CardTitle>
+        <CardDescription>Enter the share link of the document</CardDescription>
+      </CardHeader>
+      <CardContent className="space-y-4">
+        <Alert>
+          <AlertDescription>
+            Paste the URL of a shared Google Document.
+          </AlertDescription>
+        </Alert>
+        <form onSubmit={handleSubmit} className="space-y-4">
+          <div className="space-y-2">
+            <Label htmlFor="doc-url">Document URL</Label>
+            <Input
+              id="doc-url"
+              type="url"
+              placeholder="https://docs.google.com/document/d/..."
+              value={docUrl}
+              onChange={(e) => setDocUrl(e.target.value)}
+              required
+            />
+          </div>
+          <Button type="submit" disabled={isLoading || !docUrl.trim()} className="w-full">
+            {isLoading ? 'Saving...' : 'Add Document'}
+          </Button>
+        </form>
+      </CardContent>
+    </Card>
+  );
+};

--- a/src/components/integrations/forms/GoogleSheetConnectionForm.tsx
+++ b/src/components/integrations/forms/GoogleSheetConnectionForm.tsx
@@ -1,0 +1,58 @@
+import { useState } from 'react';
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import { Alert, AlertDescription } from '@/components/ui/alert';
+import { FileText } from 'lucide-react';
+
+interface GoogleSheetConnectionFormProps {
+  onConnect: (url: string) => Promise<void>;
+  isLoading: boolean;
+}
+
+export const GoogleSheetConnectionForm = ({ onConnect, isLoading }: GoogleSheetConnectionFormProps) => {
+  const [sheetUrl, setSheetUrl] = useState('');
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    if (!sheetUrl.trim()) return;
+    await onConnect(sheetUrl.trim());
+    setSheetUrl('');
+  };
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle className="flex items-center gap-2">
+          <FileText className="w-5 h-5 text-green-500" />
+          Add Google Spreadsheet
+        </CardTitle>
+        <CardDescription>Enter the share link of the spreadsheet</CardDescription>
+      </CardHeader>
+      <CardContent className="space-y-4">
+        <Alert>
+          <AlertDescription>
+            Paste the URL of a shared Google Spreadsheet.
+          </AlertDescription>
+        </Alert>
+        <form onSubmit={handleSubmit} className="space-y-4">
+          <div className="space-y-2">
+            <Label htmlFor="sheet-url">Spreadsheet URL</Label>
+            <Input
+              id="sheet-url"
+              type="url"
+              placeholder="https://docs.google.com/spreadsheets/d/..."
+              value={sheetUrl}
+              onChange={(e) => setSheetUrl(e.target.value)}
+              required
+            />
+          </div>
+          <Button type="submit" disabled={isLoading || !sheetUrl.trim()} className="w-full">
+            {isLoading ? 'Saving...' : 'Add Spreadsheet'}
+          </Button>
+        </form>
+      </CardContent>
+    </Card>
+  );
+};

--- a/src/hooks/integrations/useGoogleDocs.tsx
+++ b/src/hooks/integrations/useGoogleDocs.tsx
@@ -1,0 +1,66 @@
+import { useCallback } from 'react';
+import { FileText } from 'lucide-react';
+import { useToast } from '@/hooks/use-toast';
+import { APIIntegration } from '@/types/apiIntegrations';
+
+export const useGoogleDocs = () => {
+  const { toast } = useToast();
+
+  const connectGoogleDoc = useCallback(async (url: string) => {
+    try {
+      const match = url.match(/\/document\/d\/([a-zA-Z0-9-_]+)/);
+      if (!match) {
+        throw new Error('Invalid Google Docs URL');
+      }
+      const docId = match[1];
+
+      const integration: APIIntegration = {
+        id: `google-doc-${docId}`,
+        name: 'Google Doc',
+        provider: 'google-docs',
+        status: 'connected',
+        lastSync: new Date().toLocaleString(),
+        description: 'Document from Google Docs',
+        icon: <FileText className="w-4 h-4 text-green-500" />,
+        category: 'docs',
+        hasData: true,
+        metrics: {
+          'Doc ID': docId,
+          'Status': 'Connected'
+        }
+      };
+
+      toast({
+        title: 'Google Document Added',
+        description: 'Document URL saved',
+      });
+
+      return { integration, data: { url } };
+    } catch (error) {
+      const errorMessage = error instanceof Error ? error.message : 'Unknown error occurred';
+
+      const failedIntegration: APIIntegration = {
+        id: 'google-doc',
+        name: 'Google Doc',
+        provider: 'google-docs',
+        status: 'error',
+        lastSync: null,
+        description: 'Document from Google Docs',
+        icon: <FileText className="w-4 h-4 text-red-500" />,
+        category: 'docs',
+        hasData: false,
+        errorMessage
+      };
+
+      toast({
+        title: 'Google Doc Error',
+        description: errorMessage,
+        variant: 'destructive',
+      });
+
+      return { integration: failedIntegration, data: null };
+    }
+  }, [toast]);
+
+  return { connectGoogleDoc };
+};

--- a/src/hooks/integrations/useGoogleSheets.tsx
+++ b/src/hooks/integrations/useGoogleSheets.tsx
@@ -1,0 +1,66 @@
+import { useCallback } from 'react';
+import { FileText } from 'lucide-react';
+import { useToast } from '@/hooks/use-toast';
+import { APIIntegration } from '@/types/apiIntegrations';
+
+export const useGoogleSheets = () => {
+  const { toast } = useToast();
+
+  const connectGoogleSheet = useCallback(async (url: string) => {
+    try {
+      const match = url.match(/\/spreadsheets\/d\/([a-zA-Z0-9-_]+)/);
+      if (!match) {
+        throw new Error('Invalid Google Sheets URL');
+      }
+      const sheetId = match[1];
+
+      const integration: APIIntegration = {
+        id: `google-sheet-${sheetId}`,
+        name: 'Google Sheet',
+        provider: 'google-sheets',
+        status: 'connected',
+        lastSync: new Date().toLocaleString(),
+        description: 'Spreadsheet from Google Sheets',
+        icon: <FileText className="w-4 h-4 text-green-500" />,
+        category: 'docs',
+        hasData: true,
+        metrics: {
+          'Sheet ID': sheetId,
+          'Status': 'Connected'
+        }
+      };
+
+      toast({
+        title: 'Google Sheet Added',
+        description: 'Spreadsheet URL saved',
+      });
+
+      return { integration, data: { url } };
+    } catch (error) {
+      const errorMessage = error instanceof Error ? error.message : 'Unknown error occurred';
+
+      const failedIntegration: APIIntegration = {
+        id: 'google-sheet',
+        name: 'Google Sheet',
+        provider: 'google-sheets',
+        status: 'error',
+        lastSync: null,
+        description: 'Spreadsheet from Google Sheets',
+        icon: <FileText className="w-4 h-4 text-red-500" />,
+        category: 'docs',
+        hasData: false,
+        errorMessage
+      };
+
+      toast({
+        title: 'Google Sheet Error',
+        description: errorMessage,
+        variant: 'destructive',
+      });
+
+      return { integration: failedIntegration, data: null };
+    }
+  }, [toast]);
+
+  return { connectGoogleSheet };
+};

--- a/src/types/apiIntegrations.ts
+++ b/src/types/apiIntegrations.ts
@@ -33,6 +33,9 @@ export interface RealTimeData {
   googleSheets?: {
     sheets: any[];
   };
+  googleDocs?: {
+    docs: any[];
+  };
   aiInsights?: {
     insights: any[];
   };


### PR DESCRIPTION
## Summary
- allow saving Google Docs and Sheets URLs via new forms
- add hooks for connecting docs and sheets
- update integration hook to store docs/sheets
- extend real-time data types

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_68475ffc0f748320b8e410ad1e4af0ee