### PR TITLE
Add native AI chat function

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,3 +71,7 @@ Yes, you can!
 To connect a domain, navigate to Project > Settings > Domains and click Connect Domain.
 
 Read more here: [Setting up a custom domain](https://docs.lovable.dev/tips-tricks/custom-domain#step-by-step-guide)
+
+## Built-in AI Chat
+
+Authenticated users can now access AI-powered chat without providing their own API keys. A new Supabase function `ai-chat` proxies requests to OpenAI's API. Set the `OPENAI_API_KEY` environment variable in your Supabase project to enable this feature.

--- a/src/components/integrations/AskAIPanel.tsx
+++ b/src/components/integrations/AskAIPanel.tsx
@@ -96,7 +96,7 @@ export const AskAIPanel = ({ context }: AskAIPanelProps) => {
       const errorMessage: ChatMessage = {
         id: (Date.now() + 1).toString(),
         type: 'ai',
-        content: "Sorry, I couldn't process your request. Please ensure you have an AI API connected.",
+        content: "Sorry, I couldn't process your request. Please try again later.",
         timestamp: new Date().toLocaleTimeString()
       };
       setChatHistory(prev => [...prev, errorMessage]);
@@ -134,7 +134,7 @@ export const AskAIPanel = ({ context }: AskAIPanelProps) => {
       const errorMessage: ChatMessage = {
         id: (Date.now() + 1).toString(),
         type: 'ai',
-        content: "Sorry, I couldn't process your request. Please ensure you have an AI API connected.",
+        content: "Sorry, I couldn't process your request. Please try again later.",
         timestamp: new Date().toLocaleTimeString()
       };
       setChatHistory(prev => [...prev, errorMessage]);

--- a/src/utils/aiService.ts
+++ b/src/utils/aiService.ts
@@ -1,6 +1,5 @@
 
 import { supabase } from '@/integrations/supabase/client';
-import { credentialsService } from '@/services/credentialsService';
 
 interface AIInsight {
   title: string;
@@ -19,126 +18,28 @@ export const generateAIInsight = async (query: string): Promise<AIInsight> => {
       throw new Error('User not authenticated');
     }
 
-    // Get AI integrations for the user
-    const { data: integrations, error } = await supabase
-      .from('api_integrations')
-      .select('*')
-      .eq('user_id', user.id)
-      .eq('category', 'ai')
-      .eq('status', 'connected');
+  // Invoke the AI chat function on the backend
+  const { data, error } = await supabase.functions.invoke('ai-chat', {
+    body: { query }
+  });
 
-    if (error) {
-      console.error('Error fetching AI integrations:', error);
-      throw new Error('Failed to get AI integrations');
-    }
+  if (error) {
+    console.error('AI function error:', error);
+    throw new Error(error.message || 'Failed to generate AI insight');
+  }
 
-    if (!integrations || integrations.length === 0) {
-      throw new Error('No AI API connected. Please connect an AI API first.');
-    }
+  const content = (data as any)?.content || 'No response generated';
 
-    // Use the first available AI integration
-    const aiIntegration = integrations[0];
-    
-    // Get the API key for this integration
-    const credentials = await credentialsService.getIntegrationCredentials(aiIntegration.id);
-    
-    if (!credentials.api_key) {
-      throw new Error('No API key found for AI integration');
-    }
-
-    let response: Response;
-    let result: any;
-
-    if (aiIntegration.provider === 'openai') {
-      console.log('Using OpenAI for query:', query);
-      response = await fetch('https://api.openai.com/v1/chat/completions', {
-        method: 'POST',
-        headers: {
-          'Authorization': `Bearer ${credentials.api_key}`,
-          'Content-Type': 'application/json'
-        },
-        body: JSON.stringify({
-          model: credentials.model || 'gpt-4o-mini',
-          messages: [
-            {
-              role: 'system',
-              content: 'You are a business intelligence assistant. Provide concise, actionable insights based on the user\'s query. Focus on practical recommendations and key metrics.'
-            },
-            {
-              role: 'user',
-              content: query
-            }
-          ],
-          max_tokens: 300,
-          temperature: 0.7
-        })
-      });
-
-      if (!response.ok) {
-        const errorData = await response.json().catch(() => null);
-        throw new Error(`OpenAI API error: ${response.status} - ${errorData?.error?.message || 'Unknown error'}`);
+  return {
+    title: 'AI Insight',
+    content,
+    confidence: 'High',
+    metadata: {
+      metrics: {
+        Provider: 'OpenAI'
       }
-
-      result = await response.json();
-      const content = result.choices[0]?.message?.content || 'No response generated';
-
-      return {
-        title: 'AI Insight',
-        content,
-        confidence: 'High',
-        metadata: {
-          metrics: {
-            'Model': credentials.model || 'gpt-4o-mini',
-            'Provider': 'OpenAI',
-            'Tokens': result.usage?.total_tokens || 0
-          }
-        }
-      };
-
-    } else if (aiIntegration.provider === 'claude') {
-      console.log('Using Claude for query:', query);
-      response = await fetch('https://api.anthropic.com/v1/messages', {
-        method: 'POST',
-        headers: {
-          'x-api-key': credentials.api_key,
-          'Content-Type': 'application/json',
-          'anthropic-version': '2023-06-01'
-        },
-        body: JSON.stringify({
-          model: credentials.model || 'claude-3-haiku-20240307',
-          max_tokens: 300,
-          messages: [
-            {
-              role: 'user',
-              content: `You are a business intelligence assistant. Provide concise, actionable insights based on this query: ${query}`
-            }
-          ]
-        })
-      });
-
-      if (!response.ok) {
-        const errorData = await response.json().catch(() => null);
-        throw new Error(`Claude API error: ${response.status} - ${errorData?.error?.message || 'Unknown error'}`);
-      }
-
-      result = await response.json();
-      const content = result.content[0]?.text || 'No response generated';
-
-      return {
-        title: 'AI Insight',
-        content,
-        confidence: 'High',
-        metadata: {
-          metrics: {
-            'Model': credentials.model || 'claude-3-haiku-20240307',
-            'Provider': 'Anthropic',
-            'Usage': result.usage?.output_tokens || 0
-          }
-        }
-      };
     }
-
-    throw new Error(`Unsupported AI provider: ${aiIntegration.provider}`);
+  };
 
   } catch (error) {
     console.error('AI service error:', error);

--- a/supabase/functions/ai-chat/index.ts
+++ b/supabase/functions/ai-chat/index.ts
@@ -1,0 +1,93 @@
+import { serve } from "https://deno.land/std@0.190.0/http/server.ts";
+import { createClient } from "https://esm.sh/@supabase/supabase-js@2";
+
+const corsHeaders = {
+  'Access-Control-Allow-Origin': '*',
+  'Access-Control-Allow-Headers': 'authorization, x-client-info, apikey, content-type',
+};
+
+interface ChatRequest {
+  query: string;
+}
+
+serve(async (req) => {
+  if (req.method === 'OPTIONS') {
+    return new Response('ok', { headers: corsHeaders });
+  }
+
+  try {
+    const supabaseClient = createClient(
+      Deno.env.get('SUPABASE_URL') ?? '',
+      Deno.env.get('SUPABASE_ANON_KEY') ?? '',
+      {
+        global: {
+          headers: { Authorization: req.headers.get('Authorization')! },
+        },
+      }
+    );
+
+    const { data: { user } } = await supabaseClient.auth.getUser();
+    if (!user) {
+      return new Response(JSON.stringify({ error: 'Unauthorized' }), {
+        status: 401,
+        headers: { ...corsHeaders, 'Content-Type': 'application/json' },
+      });
+    }
+
+    const { query }: ChatRequest = await req.json();
+    if (!query) {
+      return new Response(JSON.stringify({ error: 'Missing query' }), {
+        status: 400,
+        headers: { ...corsHeaders, 'Content-Type': 'application/json' },
+      });
+    }
+
+    const apiKey = Deno.env.get('OPENAI_API_KEY');
+    if (!apiKey) {
+      return new Response(JSON.stringify({ error: 'AI service not configured' }), {
+        status: 500,
+        headers: { ...corsHeaders, 'Content-Type': 'application/json' },
+      });
+    }
+
+    const response = await fetch('https://api.openai.com/v1/chat/completions', {
+      method: 'POST',
+      headers: {
+        'Authorization': `Bearer ${apiKey}`,
+        'Content-Type': 'application/json'
+      },
+      body: JSON.stringify({
+        model: 'gpt-4o-mini',
+        messages: [
+          { role: 'system', content: 'You are a helpful assistant that responds concisely.' },
+          { role: 'user', content: query }
+        ],
+        max_tokens: 300,
+        temperature: 0.7
+      })
+    });
+
+    if (!response.ok) {
+      const errorText = await response.text();
+      console.error('AI API error:', errorText);
+      return new Response(JSON.stringify({ error: 'Failed to generate response' }), {
+        status: 500,
+        headers: { ...corsHeaders, 'Content-Type': 'application/json' },
+      });
+    }
+
+    const result = await response.json();
+    const content = result.choices?.[0]?.message?.content ?? '';
+
+    return new Response(JSON.stringify({ content }), {
+      headers: { ...corsHeaders, 'Content-Type': 'application/json' },
+    });
+
+  } catch (error) {
+    console.error('AI chat error:', error);
+    return new Response(JSON.stringify({ error: 'Internal server error' }), {
+      status: 500,
+      headers: { ...corsHeaders, 'Content-Type': 'application/json' },
+    });
+  }
+});


### PR DESCRIPTION
## Summary
- add `ai-chat` Supabase function that proxies to OpenAI
- simplify `generateAIInsight` to use the backend function
- tweak AskAIPanel error message
- document built-in AI chat in README

## Testing
- `npm run lint` *(fails: 36 errors, 9 warnings)*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_684806f454b883208ef63fb0815af59b