### PR TITLE
Add analytics folder and python integration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,6 @@ dist-ssr
 *.njsproj
 *.sln
 *.sw?
+
+# Analytics output
+analytics/documents/*.png

--- a/README.md
+++ b/README.md
@@ -71,3 +71,19 @@ Yes, you can!
 To connect a domain, navigate to Project > Settings > Domains and click Connect Domain.
 
 Read more here: [Setting up a custom domain](https://docs.lovable.dev/tips-tricks/custom-domain#step-by-step-guide)
+
+## Analytics and Python setup
+
+This project includes an `analytics` directory for storing documents and running Python based analysis. After installing dependencies, create the analytics folders by running:
+
+```sh
+npm run setup:analytics
+```
+
+Place JSON files containing API data inside `analytics/documents/`. You can then run the analytics script which will generate example visualisations in the same folder:
+
+```sh
+npm run analytics
+```
+
+Python dependencies for the script are listed in `analytics/requirements.txt`.

--- a/analytics/analyze.py
+++ b/analytics/analyze.py
@@ -1,0 +1,40 @@
+import json
+from pathlib import Path
+import pandas as pd
+import matplotlib.pyplot as plt
+import seaborn as sns
+
+DOCS_DIR = Path(__file__).resolve().parent / "documents"
+
+
+def load_data() -> pd.DataFrame:
+    files = list(DOCS_DIR.glob("*.json"))
+    if not files:
+        print("No JSON files found in documents directory.")
+        return pd.DataFrame()
+    frames = []
+    for file in files:
+        with open(file, "r") as f:
+            frames.append(pd.json_normalize(json.load(f)))
+    return pd.concat(frames, ignore_index=True)
+
+
+def main() -> None:
+    df = load_data()
+    if df.empty:
+        print("No data loaded for analysis.")
+        return
+    if {"month", "revenue"}.issubset(df.columns):
+        plt.figure(figsize=(10, 6))
+        sns.barplot(data=df, x="month", y="revenue", color="skyblue")
+        plt.title("Revenue by Month")
+        plt.tight_layout()
+        out_path = DOCS_DIR / "revenue_by_month.png"
+        plt.savefig(out_path)
+        print(f"Saved visualisation to {out_path}")
+    else:
+        print("Required columns 'month' and 'revenue' not found in data.")
+
+
+if __name__ == "__main__":
+    main()

--- a/analytics/requirements.txt
+++ b/analytics/requirements.txt
@@ -1,0 +1,3 @@
+pandas
+matplotlib
+seaborn

--- a/package.json
+++ b/package.json
@@ -8,7 +8,9 @@
     "build": "vite build",
     "build:dev": "vite build --mode development",
     "lint": "eslint .",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "setup:analytics": "node scripts/setupAnalytics.cjs",
+    "analytics": "python analytics/analyze.py"
   },
   "dependencies": {
     "@hookform/resolvers": "^3.9.0",

--- a/scripts/setupAnalytics.cjs
+++ b/scripts/setupAnalytics.cjs
@@ -1,0 +1,11 @@
+const fs = require('fs');
+const path = require('path');
+
+const docsDir = path.join(__dirname, '..', 'analytics', 'documents');
+
+if (!fs.existsSync(docsDir)) {
+  fs.mkdirSync(docsDir, { recursive: true });
+  console.log(`Created analytics documents directory at ${docsDir}`);
+} else {
+  console.log(`Analytics documents directory already exists at ${docsDir}`);
+}


### PR DESCRIPTION
## Summary
- create `analytics` folder with sample Python analytics script
- add Node setup script to ensure `analytics/documents` exists
- ignore generated analytics images
- add npm scripts for running analytics and setup
- document Python analytics usage in README

## Testing
- `npm run lint` *(fails: several lint errors)*
- `npm run build`
- `python analytics/analyze.py` *(fails: ModuleNotFoundError for pandas)*

------
https://chatgpt.com/codex/tasks/task_e_6848112811d0832096f33d602d1274c3