### PR TITLE
Add Refresh Cache feature

### DIFF
--- a/src/hooks/useRefreshCache.ts
+++ b/src/hooks/useRefreshCache.ts
@@ -1,0 +1,31 @@
+import { useState, useCallback } from 'react';
+import { supabase } from '@/integrations/supabase/client';
+import { useToast } from '@/hooks/use-toast';
+
+export const useRefreshCache = () => {
+  const [isRefreshing, setIsRefreshing] = useState(false);
+  const { toast } = useToast();
+
+  const refreshCache = useCallback(async () => {
+    setIsRefreshing(true);
+    try {
+      const { error } = await supabase.functions.invoke('refresh-cache');
+      if (error) throw error;
+      toast({
+        title: 'Cache Refreshed',
+        description: 'The cache has been cleared successfully.',
+      });
+    } catch (error) {
+      console.error('Failed to refresh cache:', error);
+      toast({
+        title: 'Refresh Failed',
+        description: 'Unable to refresh cache.',
+        variant: 'destructive',
+      });
+    } finally {
+      setIsRefreshing(false);
+    }
+  }, [toast]);
+
+  return { isRefreshing, refreshCache };
+};

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -8,6 +8,9 @@ import { TrelloTab } from "@/components/tabs/TrelloTab";
 import { CalendlyTab } from "@/components/tabs/CalendlyTab";
 import { GoogleDriveTab } from "@/components/tabs/GoogleDriveTab";
 import { GoogleCalendarDashboard } from "@/components/tabs/GoogleCalendarDashboard";
+import { Button } from "@/components/ui/button";
+import { RefreshCw } from "lucide-react";
+import { useRefreshCache } from "@/hooks/useRefreshCache";
 import { ProtectedRoute } from "@/components/auth/ProtectedRoute";
 import { Header } from "@/components/layout/Header";
 import { useAPIIntegrations } from "@/hooks/useAPIIntegrations";
@@ -15,6 +18,7 @@ import { useAPIIntegrations } from "@/hooks/useAPIIntegrations";
 const Index = () => {
   const [activeTab, setActiveTab] = useState("analytics");
   const { integrations } = useAPIIntegrations();
+  const { refreshCache, isRefreshing } = useRefreshCache();
 
   // Filter only connected integrations
   const connectedIntegrations = integrations.filter(int => int.status === 'connected');
@@ -43,6 +47,15 @@ const Index = () => {
               <p className="text-xl text-muted-foreground">
                 Your unified dashboard for sales analytics and integrations
               </p>
+              <Button
+                variant="outline"
+                size="sm"
+                onClick={refreshCache}
+                disabled={isRefreshing}
+              >
+                <RefreshCw className={`w-4 h-4 mr-1 ${isRefreshing ? 'animate-spin' : ''}`} />
+                {isRefreshing ? 'Refreshing...' : 'Refresh Cache'}
+              </Button>
             </div>
 
             <Tabs value={activeTab} onValueChange={setActiveTab} className="w-full">

--- a/supabase/functions/refresh-cache/index.ts
+++ b/supabase/functions/refresh-cache/index.ts
@@ -1,0 +1,57 @@
+import { serve } from "https://deno.land/std@0.190.0/http/server.ts";
+import { createClient } from "https://esm.sh/@supabase/supabase-js@2";
+
+const corsHeaders = {
+  'Access-Control-Allow-Origin': '*',
+  'Access-Control-Allow-Headers': 'authorization, x-client-info, apikey, content-type',
+};
+
+serve(async (req) => {
+  if (req.method === 'OPTIONS') {
+    return new Response('ok', { headers: corsHeaders });
+  }
+
+  try {
+    const supabaseClient = createClient(
+      Deno.env.get('SUPABASE_URL') ?? '',
+      Deno.env.get('SUPABASE_ANON_KEY') ?? '',
+      {
+        global: {
+          headers: { Authorization: req.headers.get('Authorization')! },
+        },
+      }
+    );
+
+    const { data: { user } } = await supabaseClient.auth.getUser();
+    if (!user) {
+      return new Response(JSON.stringify({ error: 'Unauthorized' }), {
+        status: 401,
+        headers: { ...corsHeaders, 'Content-Type': 'application/json' },
+      });
+    }
+
+    const { error } = await supabaseClient
+      .from('calendly_availability_cache')
+      .delete()
+      .eq('user_id', user.id);
+
+    if (error) {
+      console.error('Database error:', error);
+      return new Response(JSON.stringify({ error: 'Failed to clear cache' }), {
+        status: 500,
+        headers: { ...corsHeaders, 'Content-Type': 'application/json' },
+      });
+    }
+
+    return new Response(JSON.stringify({ success: true }), {
+      headers: { ...corsHeaders, 'Content-Type': 'application/json' },
+    });
+
+  } catch (error) {
+    console.error('Error:', error);
+    return new Response(JSON.stringify({ error: 'Internal server error' }), {
+      status: 500,
+      headers: { ...corsHeaders, 'Content-Type': 'application/json' },
+    });
+  }
+});


### PR DESCRIPTION
## Summary
- add a Supabase edge function to clear the Calendly availability cache
- create `useRefreshCache` hook for invoking the refresh
- display **Refresh Cache** button on the dashboard

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_6848639602d48320ac9850426cd1ce80